### PR TITLE
Use universal module definition

### DIFF
--- a/src/js/chasecam.js
+++ b/src/js/chasecam.js
@@ -1,4 +1,12 @@
-define(["three"], function(THREE) {
+(function (root, factory) {
+    if (typeof define === 'function' && define.amd) {
+        define(['three'], factory);
+    } else if (typeof module === 'object' && module.exports) {
+        module.exports = factory(require('three'));
+    } else {
+        root.ThreeChaseCam = factory(root.THREE);
+    }
+}(this, function (THREE) {
 
     var GfxChasecam = {
 
@@ -120,6 +128,5 @@ define(["three"], function(THREE) {
 
     };
 
-
     return GfxChasecam;
-});
+}));


### PR DESCRIPTION
Instead of being an AMD module, allow it to be AMD, CommonJS or standard global instead. 

Tests pass.
